### PR TITLE
重构 UnPeekLiveData，最终实现对谷歌原生 LiveData 完全无侵入性的目的。在多人协作的场景下，其他同学就只需要理解 U…

### DIFF
--- a/app/src/main/java/com/kunminx/puremusic/ui/ListFragment.java
+++ b/app/src/main/java/com/kunminx/puremusic/ui/ListFragment.java
@@ -70,12 +70,12 @@ public class ListFragment extends BaseFragment {
             mListViewModel.list.setValue(moments);
         });
 
-        mSharedViewModel.getMoment().observeInFragment(this, moment -> {
+        mSharedViewModel.getMoment().observe(this, moment -> {
             mListViewModel.list.getValue().add(0, moment);
             mListViewModel.list.setValue(mListViewModel.list.getValue());
         });
 
-        mSharedViewModel.getTestDelayMsg().observeInFragment(this, s -> {
+        mSharedViewModel.getTestDelayMsg().observe(this, s -> {
             if (!TextUtils.isEmpty(s)) {
                 showLongToast(s);
             }

--- a/app/src/main/java/com/kunminx/puremusic/ui/MainActivity.java
+++ b/app/src/main/java/com/kunminx/puremusic/ui/MainActivity.java
@@ -47,11 +47,11 @@ public class MainActivity extends BaseActivity {
         ActivityMainBinding binding = DataBindingUtil.setContentView(this, R.layout.activity_main);
         binding.setClick(new ClickProxy());
 
-        mSharedViewModel.getMoment().observeInActivity(this, moment -> {
+        mSharedViewModel.getMoment().observe(this, moment -> {
             Toast.makeText(this, moment.getContent(), Toast.LENGTH_SHORT).show();
         });
 
-        mSharedViewModel.getTestDelayMsg().observeInActivity(this, s -> {
+        mSharedViewModel.getTestDelayMsg().observe(this, s -> {
             if (!TextUtils.isEmpty(s)) {
                 showLongToast(s);
             }

--- a/unpeeklivedata/src/main/java/com/kunminx/architecture/ui/callback/ProtectedUnPeekLiveData.java
+++ b/unpeeklivedata/src/main/java/com/kunminx/architecture/ui/callback/ProtectedUnPeekLiveData.java
@@ -18,15 +18,13 @@
 package com.kunminx.architecture.ui.callback;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelStore;
-
-import java.util.HashMap;
+import com.kunminx.architecture.ui.callback.util.LiveDataUtil;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * TODO：UnPeekLiveData 的存在是为了在 "重回二级页面" 的场景下，解决 "数据倒灌" 的问题。
@@ -34,109 +32,163 @@ import java.util.Map;
  * <p>
  * https://xiaozhuanlan.com/topic/6719328450
  * <p>
- * 本类参考了官方 SingleEventLive 的非入侵设计，
- * 以及小伙伴 Flywith24 在 wrapperLiveData 中通过 ViewModelStore 来唯一确定订阅者的思路，
- * <p>
- * TODO：在当前最新版中，我们透过对 ViewModelStore 的内存地址的遍历，
- * 来确保：
- * 1.一条消息能被多个观察者消费
- * 2.消息被所有观察者消费完毕后才开始阻止倒灌
- * 3.可以通过 clear 方法手动将消息从内存中移除
- * 4.让非入侵设计成为可能，遵循开闭原则
+ *
+ * 对{@link ProtectedUnPeekLiveDataV4}进行了重构，修复了V4版本的已知问题：
+ * TODO: 1、UnPeekLiveData 中的 observers 这个 HashMap 恒久存在，注册的 Observer 越多，占用的内存越大，并且除非 UnPeekLiveData 被回收，否则恒久存在内存当中
+ * 在 removeObserver 方法中移除 map 中对应存储的 storeId
+ *
+ * TODO: 2、无法通过 removeObserver 方法移除指定的 Observer（某些场景需要提前 removeObserver）
+ * 通过维护外部传入 Observer 与内部代理 Observer 的映射关系，在 removeObserver 调用时，通过反射找到真正注册到 LiveData 中的 Observer，实现移除
+ *
+ * TODO: 3、同一个 Observer 对象，注册多次，UnPeekLiveData 内部实际上会注册了多个不同的 Observer，从而导致重复回调，产生一些不可预期的问题
+ * 内部不会每次调用 observe 方法时都新创建一个代理 Observer，而是复用已经存在的代理 Observer
+ * 注意！！！Kotlin + LiveData + Lamda 由于编译器优化，可能会抛 Cannot add the same observer with different lifecycles 异常
+ *
+ * TODO: 4、无法使用 observerForever 方法
+ * UnPeekLiveData 内部直接持有 forever 类型的 Observer
+ *
+ * TODO: 最终实现对谷歌原生 LiveData 完全无侵入性的目的。在多人协作的场景下，其他同学就只需要理解 UnPeekLiveData 能够解决粘性事件、数据倒灌问题，其他的完全不需要理解，用法上完全跟原生 LiveData 保持一致
+ *
  * <p>
  * TODO：增加一层 ProtectedUnPeekLiveData，
  * 用于限制从 Activity/Fragment 篡改来自 "数据层" 的数据，数据层的数据务必通过 "唯一可信源" 来分发，
  * 如果这样说还不理解，详见：
  * https://xiaozhuanlan.com/topic/0168753249 和 https://xiaozhuanlan.com/topic/6719328450
  * <p>
- * Create by KunMinX at 19/9/23
+ *
+ * Create by Jim at 2021/4/21
  */
 public class ProtectedUnPeekLiveData<T> extends LiveData<T> {
 
-  protected boolean isAllowNullValue;
+    protected boolean isAllowNullValue;
 
-  private final HashMap<Integer, Boolean> observers = new HashMap<>();
+    private final ConcurrentHashMap<Integer, Boolean> observers = new ConcurrentHashMap<>();
 
-  /**
-   * 适合在 activity 中使用的 observe UnPeek 方法
-   * A Observe UnPeek method which suitable for use in an activity
-   *
-   * @param activity
-   * @param observer
-   */
-  public void observeInActivity(@NonNull AppCompatActivity activity, @NonNull Observer<? super T> observer) {
-    LifecycleOwner owner = activity;
-    Integer storeId = System.identityHashCode(activity.getViewModelStore());
-    observe(storeId, owner, observer);
-  }
+    /**
+     * 保存外部传入的Observer与代理Observer之间的映射关系
+     */
+    private final ConcurrentHashMap<Integer, Integer> observerMap = new ConcurrentHashMap<>();
 
-  /**
-   * 适合在 fragment 中使用的 observe UnPeek 方法
-   * A Observe UnPeek method which suitable for use in an fragment
-   *
-   * @param fragment
-   * @param observer
-   */
-  public void observeInFragment(@NonNull Fragment fragment, @NonNull Observer<? super T> observer) {
-    LifecycleOwner owner = fragment.getViewLifecycleOwner();
-    Integer storeId = System.identityHashCode(fragment.getViewModelStore());
-    observe(storeId, owner, observer);
-  }
+    /**
+     * 这里会持有永久性注册的Observer对象，因为是永久性注册的，必须调用remove才会注销，所有这里持有Observer对象不存在内存泄漏问题，
+     * 因为一旦泄漏了，只能说明是业务使用方没有remove
+     */
+    private final ConcurrentHashMap<Integer, Observer> foreverObservers = new ConcurrentHashMap<>();
 
-  /**
-   * 通用的 observe UnPeek 方法
-   * A universal Observe UnPeek method
-   *
-   * @param owner
-   * @param store
-   * @param observer
-   */
-  public void observeUnPeek(@NonNull LifecycleOwner owner, @NonNull ViewModelStore store, @NonNull Observer<? super T> observer) {
-    Integer storeId = System.identityHashCode(store);
-    observe(storeId, owner, observer);
-  }
-
-  private void observe(@NonNull Integer storeId,
-                       @NonNull LifecycleOwner owner,
-                       @NonNull Observer<? super T> observer) {
-
-    if (observers.get(storeId) == null) {
-      observers.put(storeId, true);
+    private Observer<T> createProxyObserver(@NonNull Observer originalObserver, @NonNull Integer storeId) {
+        return t -> {
+            if (!observers.get(storeId)) {
+                observers.put(storeId, true);
+                if (t != null || isAllowNullValue) {
+                    originalObserver.onChanged(t);
+                }
+            }
+        };
     }
 
-    super.observe(owner, t -> {
-      if (!observers.get(storeId)) {
-        observers.put(storeId, true);
-        if (t != null || isAllowNullValue) {
-          observer.onChanged(t);
+    @Override
+    public void observe(@NonNull LifecycleOwner owner, @NonNull Observer<? super T> observer) {
+        if (owner instanceof Fragment && ((Fragment) owner).getViewLifecycleOwner() != null) {
+            /**
+             * 2020年起，Fragment中LiveData传入的LifeCycleOwner从fragment.this改进为getViewLifeCycleOwner。这样设计，主要是为了解决getView()的生命长度比fragment短（仅存活于onCreateView之后和onDestroyView之前），
+             * 导致某些时候fragment其他成员还活着，但getView()为null的生命周期安全问题，
+             * 也即，在Fragment的场景下，请使用getViewLifeCycleOwner来作为liveData的订阅者。（并且注意，对getViewLifeCycleOwner的使用应在onCreateView之后和onDestroyView之前）
+             */
+            owner = ((Fragment) owner).getViewLifecycleOwner();
         }
-      }
-    });
-  }
 
-  /**
-   * 重写的 setValue 方法，默认不接收 null
-   * 可通过 Builder 配置允许接收
-   * 可通过 Builder 配置消息延时清理的时间
-   * <p>
-   * override setValue, do not receive null by default
-   * You can configure to allow receiving through Builder
-   * And also, You can configure the delay time of message clearing through Builder
-   *
-   * @param value
-   */
-  @Override
-  protected void setValue(T value) {
-    if (value != null || isAllowNullValue) {
-      for (Map.Entry<Integer, Boolean> entry : observers.entrySet()) {
-        entry.setValue(false);
-      }
-      super.setValue(value);
+        Integer storeId = System.identityHashCode(observer);
+        observe(storeId, owner, observer);
     }
-  }
 
-  public void clear() {
-    super.setValue(null);
-  }
+    @Override
+    public void observeForever(@NonNull Observer<? super T> observer) {
+        Integer storeId = System.identityHashCode(observer);
+        observeForever(storeId, observer);
+    }
+
+    private void observe(@NonNull Integer storeId,
+                         @NonNull LifecycleOwner owner,
+                         @NonNull Observer<? super T> observer) {
+
+        if (observers.get(storeId) == null) {
+            observers.put(storeId, true);
+        }
+
+        Observer registerObserver;
+        if (observerMap.get(storeId) == null) {
+            registerObserver = createProxyObserver(observer, storeId);
+            // 保存外部Observer以及内部代理Observer的映射关系
+            observerMap.put(storeId, System.identityHashCode(registerObserver));
+        } else {
+            // 通过反射拿到真正注册到LiveData中的Observer
+            Integer registerObserverStoreId = observerMap.get(storeId);
+            registerObserver = LiveDataUtil.getObserver(this, registerObserverStoreId);
+            if (registerObserver == null) {
+                registerObserver = createProxyObserver(observer, storeId);
+                // 保存外部Observer以及内部代理Observer的映射关系
+                observerMap.put(storeId, System.identityHashCode(registerObserver));
+            }
+        }
+
+        super.observe(owner, registerObserver);
+    }
+
+    private void observeForever(@NonNull Integer storeId, @NonNull Observer<? super T> observer) {
+
+        if (observers.get(storeId) == null) {
+            observers.put(storeId, true);
+        }
+
+        Observer registerObserver = foreverObservers.get(storeId);
+        if (registerObserver == null) {
+            registerObserver = createProxyObserver(observer, storeId);
+            foreverObservers.put(storeId, registerObserver);
+        }
+
+        super.observeForever(registerObserver);
+    }
+
+    @Override
+    public void removeObserver(@NonNull Observer<? super T> observer) {
+        Integer storeId = System.identityHashCode(observer);
+        Observer registerObserver = foreverObservers.remove(storeId);
+        if (registerObserver == null && observerMap.containsKey(storeId)) {
+            // 反射拿到真正注册到LiveData中的observer
+            Integer registerObserverStoreId = observerMap.remove(storeId);
+            registerObserver = LiveDataUtil.getObserver(this, registerObserverStoreId);
+        }
+
+        if (registerObserver != null) {
+            observers.remove(storeId);
+        }
+
+        super.removeObserver(registerObserver != null ? registerObserver : observer);
+    }
+
+    /**
+     * 重写的 setValue 方法，默认不接收 null
+     * 可通过 Builder 配置允许接收
+     * 可通过 Builder 配置消息延时清理的时间
+     * <p>
+     * override setValue, do not receive null by default
+     * You can configure to allow receiving through Builder
+     * And also, You can configure the delay time of message clearing through Builder
+     *
+     * @param value
+     */
+    @Override
+    protected void setValue(T value) {
+        if (value != null || isAllowNullValue) {
+            for (Map.Entry<Integer, Boolean> entry : observers.entrySet()) {
+                entry.setValue(false);
+            }
+            super.setValue(value);
+        }
+    }
+
+    public void clear() {
+        super.setValue(null);
+    }
 }
 

--- a/unpeeklivedata/src/main/java/com/kunminx/architecture/ui/callback/ProtectedUnPeekLiveDataV4.java
+++ b/unpeeklivedata/src/main/java/com/kunminx/architecture/ui/callback/ProtectedUnPeekLiveDataV4.java
@@ -1,0 +1,143 @@
+
+/*
+ * Copyright 2018-present KunMinX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kunminx.architecture.ui.callback;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelStore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * TODO：UnPeekLiveData 的存在是为了在 "重回二级页面" 的场景下，解决 "数据倒灌" 的问题。
+ * 对 "数据倒灌" 的状况不理解的小伙伴，可参考《LiveData 数据倒灌 背景缘由全貌 独家解析》文章开头的解析
+ * <p>
+ * https://xiaozhuanlan.com/topic/6719328450
+ * <p>
+ * 本类参考了官方 SingleEventLive 的非入侵设计，
+ * 以及小伙伴 Flywith24 在 wrapperLiveData 中通过 ViewModelStore 来唯一确定订阅者的思路，
+ * <p>
+ * TODO：在当前最新版中，我们透过对 ViewModelStore 的内存地址的遍历，
+ * 来确保：
+ * 1.一条消息能被多个观察者消费
+ * 2.消息被所有观察者消费完毕后才开始阻止倒灌
+ * 3.可以通过 clear 方法手动将消息从内存中移除
+ * 4.让非入侵设计成为可能，遵循开闭原则
+ * <p>
+ * TODO：增加一层 ProtectedUnPeekLiveData，
+ * 用于限制从 Activity/Fragment 篡改来自 "数据层" 的数据，数据层的数据务必通过 "唯一可信源" 来分发，
+ * 如果这样说还不理解，详见：
+ * https://xiaozhuanlan.com/topic/0168753249 和 https://xiaozhuanlan.com/topic/6719328450
+ * <p>
+ * Create by KunMinX at 19/9/23
+ */
+@Deprecated
+public class ProtectedUnPeekLiveDataV4<T> extends LiveData<T> {
+
+    protected boolean isAllowNullValue;
+
+    private final HashMap<Integer, Boolean> observers = new HashMap<>();
+
+    /**
+     * 适合在 activity 中使用的 observe UnPeek 方法
+     * A Observe UnPeek method which suitable for use in an activity
+     *
+     * @param activity
+     * @param observer
+     */
+    public void observeInActivity(@NonNull AppCompatActivity activity, @NonNull Observer<? super T> observer) {
+        LifecycleOwner owner = activity;
+        Integer storeId = System.identityHashCode(activity.getViewModelStore());
+        observe(storeId, owner, observer);
+    }
+
+    /**
+     * 适合在 fragment 中使用的 observe UnPeek 方法
+     * A Observe UnPeek method which suitable for use in an fragment
+     *
+     * @param fragment
+     * @param observer
+     */
+    public void observeInFragment(@NonNull Fragment fragment, @NonNull Observer<? super T> observer) {
+        LifecycleOwner owner = fragment.getViewLifecycleOwner();
+        Integer storeId = System.identityHashCode(fragment.getViewModelStore());
+        observe(storeId, owner, observer);
+    }
+
+    /**
+     * 通用的 observe UnPeek 方法
+     * A universal Observe UnPeek method
+     *
+     * @param owner
+     * @param store
+     * @param observer
+     */
+    public void observeUnPeek(@NonNull LifecycleOwner owner, @NonNull ViewModelStore store, @NonNull Observer<? super T> observer) {
+        Integer storeId = System.identityHashCode(store);
+        observe(storeId, owner, observer);
+    }
+
+    private void observe(@NonNull Integer storeId,
+                         @NonNull LifecycleOwner owner,
+                         @NonNull Observer<? super T> observer) {
+
+        if (observers.get(storeId) == null) {
+            observers.put(storeId, true);
+        }
+
+        super.observe(owner, t -> {
+            if (!observers.get(storeId)) {
+                observers.put(storeId, true);
+                if (t != null || isAllowNullValue) {
+                    observer.onChanged(t);
+                }
+            }
+        });
+    }
+
+    /**
+     * 重写的 setValue 方法，默认不接收 null
+     * 可通过 Builder 配置允许接收
+     * 可通过 Builder 配置消息延时清理的时间
+     * <p>
+     * override setValue, do not receive null by default
+     * You can configure to allow receiving through Builder
+     * And also, You can configure the delay time of message clearing through Builder
+     *
+     * @param value
+     */
+    @Override
+    protected void setValue(T value) {
+        if (value != null || isAllowNullValue) {
+            for (Map.Entry<Integer, Boolean> entry : observers.entrySet()) {
+                entry.setValue(false);
+            }
+            super.setValue(value);
+        }
+    }
+
+    public void clear() {
+        super.setValue(null);
+    }
+}
+

--- a/unpeeklivedata/src/main/java/com/kunminx/architecture/ui/callback/UnPeekLiveData.java
+++ b/unpeeklivedata/src/main/java/com/kunminx/architecture/ui/callback/UnPeekLiveData.java
@@ -1,31 +1,36 @@
 package com.kunminx.architecture.ui.callback;
 
-import androidx.annotation.NonNull;
-import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.Observer;
-
 /**
  * TODO：UnPeekLiveData 的存在是为了在 "重回二级页面" 的场景下，解决 "数据倒灌" 的问题。
  * 对 "数据倒灌" 的状况不理解的小伙伴，可参考《LiveData 数据倒灌 背景缘由全貌 独家解析》文章开头的解析
  * <p>
  * https://xiaozhuanlan.com/topic/6719328450
  * <p>
- * 本类参考了官方 SingleEventLive 的非入侵设计，
- * 以及小伙伴 Flywith24 在 wrapperLiveData 中通过 ViewModelStore 来唯一确定订阅者的思路，
- * <p>
- * TODO：在当前最新版中，我们透过对 ViewModelStore 的内存地址的遍历，
- * 来确保：
- * 1.一条消息能被多个观察者消费
- * 2.消息被所有观察者消费完毕后才开始阻止倒灌
- * 3.可以通过 clear 方法手动将消息从内存中移除
- * 4.让非入侵设计成为可能，遵循开闭原则
+ *
+ * 对{@link ProtectedUnPeekLiveDataV4}进行了重构，修复了V4版本的已知问题：
+ * TODO: 1、UnPeekLiveData 中的 observers 这个 HashMap 恒久存在，注册的 Observer 越多，占用的内存越大，并且除非 UnPeekLiveData 被回收，否则恒久存在内存当中
+ * 在 removeObserver 方法中移除 map 中对应存储的 storeId
+ *
+ * TODO: 2、无法通过 removeObserver 方法移除指定的 Observer（某些场景需要提前 removeObserver）
+ * 通过维护外部传入 Observer 与内部代理 Observer 的映射关系，在 removeObserver 调用时，通过反射找到真正注册到 LiveData 中的 Observer，实现移除
+ *
+ * TODO: 3、同一个 Observer 对象，注册多次，UnPeekLiveData 内部实际上会注册了多个不同的 Observer，从而导致重复回调，产生一些不可预期的问题
+ * 内部不会每次调用 observe 方法时都新创建一个代理 Observer，而是复用已经存在的代理 Observer
+ * 注意！！！Kotlin + LiveData + Lamda 由于编译器优化，可能会抛 Cannot add the same observer with different lifecycles 异常
+ *
+ * TODO: 4、无法使用 observerForever 方法
+ * UnPeekLiveData 内部直接持有 forever 类型的 Observer
+ *
+ * TODO: 最终实现对谷歌原生 LiveData 完全无侵入性的目的。在多人协作的场景下，其他同学就只需要理解 UnPeekLiveData 能够解决粘性事件、数据倒灌问题，其他的完全不需要理解，用法上完全跟原生 LiveData 保持一致
+ *
  * <p>
  * TODO：增加一层 ProtectedUnPeekLiveData，
  * 用于限制从 Activity/Fragment 篡改来自 "数据层" 的数据，数据层的数据务必通过 "唯一可信源" 来分发，
  * 如果这样说还不理解，详见：
  * https://xiaozhuanlan.com/topic/0168753249 和 https://xiaozhuanlan.com/topic/6719328450
  * <p>
- * Create by KunMinX at 2020/7/21
+ *
+ * Create by Jim at 2021/4/21
  */
 public class UnPeekLiveData<T> extends ProtectedUnPeekLiveData<T> {
 
@@ -37,48 +42,6 @@ public class UnPeekLiveData<T> extends ProtectedUnPeekLiveData<T> {
     @Override
     public void postValue(T value) {
         super.postValue(value);
-    }
-
-    /**
-     * TODO：Tip：请不要在 UnPeekLiveData 中使用 observe 方法。
-     * 取而代之的是在 Activity 和 fragment 中分别使用 observeInActivity 和 observeInFragment 来观察。
-     * <p>
-     * 2020.10.15 背景缘由：
-     * UnPeekLiveData 通过 ViewModelStore 来在各种场景下（如旋屏后）确定订阅者的唯一性和消息的消费状况，
-     * 因而在 Activity 和 fragment 对 LifecycleOwner 的使用存在差异的现状下，
-     * 我们采取注入局部变量的方式，来获取 store 和 owner。
-     *
-     * @param owner
-     * @param observer
-     */
-    @Override
-    @Deprecated
-    public void observe(@NonNull LifecycleOwner owner, @NonNull Observer<? super T> observer) {
-        throw new IllegalArgumentException("请不要在 UnPeekLiveData 中使用 observe 方法。" +
-                "取而代之的是在 Activity 和 Fragment 中分别使用 observeInActivity 和 observeInFragment 来观察。\n\n" +
-                "Taking into account the normal permission of preventing backflow logic, " +
-                " do not use observeForever to communicate between pages." +
-                "Instead, you can use ObserveInActivity and ObserveInFragment methods " +
-                "to observe in Activity and Fragment respectively.");
-    }
-
-    /**
-     * TODO：Tip：请不要在 UnPeekLiveData 中使用 observeForever 方法。
-     * <p>
-     * 2020.8.1 背景缘由：
-     * UnPeekLiveData 主要用于表现层的 页面转场 和 页面间通信 场景下的非粘性消息分发，
-     * 出于生命周期安全等因素的考虑，不建议使用 observeForever 方法，
-     * <p>
-     * 对于数据层的工作，如有需要，可结合实际场景使用 RxJava 或 kotlin flow。
-     *
-     * @param observer
-     */
-    @Override
-    @Deprecated
-    public void observeForever(@NonNull Observer<? super T> observer) {
-        throw new IllegalArgumentException("出于生命周期安全的考虑，请不要在 UnPeekLiveData 中使用 observeForever 方法。\n\n" +
-                "Considering avoid lifecycle security issues," +
-                " do not use observeForever for communication between pages.");
     }
 
     public static class Builder<T> {

--- a/unpeeklivedata/src/main/java/com/kunminx/architecture/ui/callback/UnPeekLiveDataV4.java
+++ b/unpeeklivedata/src/main/java/com/kunminx/architecture/ui/callback/UnPeekLiveDataV4.java
@@ -1,0 +1,103 @@
+package com.kunminx.architecture.ui.callback;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.Observer;
+
+/**
+ * TODO：UnPeekLiveData 的存在是为了在 "重回二级页面" 的场景下，解决 "数据倒灌" 的问题。
+ * 对 "数据倒灌" 的状况不理解的小伙伴，可参考《LiveData 数据倒灌 背景缘由全貌 独家解析》文章开头的解析
+ * <p>
+ * https://xiaozhuanlan.com/topic/6719328450
+ * <p>
+ * 本类参考了官方 SingleEventLive 的非入侵设计，
+ * 以及小伙伴 Flywith24 在 wrapperLiveData 中通过 ViewModelStore 来唯一确定订阅者的思路，
+ * <p>
+ * TODO：在当前最新版中，我们透过对 ViewModelStore 的内存地址的遍历，
+ * 来确保：
+ * 1.一条消息能被多个观察者消费
+ * 2.消息被所有观察者消费完毕后才开始阻止倒灌
+ * 3.可以通过 clear 方法手动将消息从内存中移除
+ * 4.让非入侵设计成为可能，遵循开闭原则
+ * <p>
+ * TODO：增加一层 ProtectedUnPeekLiveData，
+ * 用于限制从 Activity/Fragment 篡改来自 "数据层" 的数据，数据层的数据务必通过 "唯一可信源" 来分发，
+ * 如果这样说还不理解，详见：
+ * https://xiaozhuanlan.com/topic/0168753249 和 https://xiaozhuanlan.com/topic/6719328450
+ * <p>
+ * Create by KunMinX at 2020/7/21
+ */
+@Deprecated
+public class UnPeekLiveDataV4<T> extends ProtectedUnPeekLiveData<T> {
+
+    @Override
+    public void setValue(T value) {
+        super.setValue(value);
+    }
+
+    @Override
+    public void postValue(T value) {
+        super.postValue(value);
+    }
+
+    /**
+     * TODO：Tip：请不要在 UnPeekLiveData 中使用 observe 方法。
+     * 取而代之的是在 Activity 和 fragment 中分别使用 observeInActivity 和 observeInFragment 来观察。
+     * <p>
+     * 2020.10.15 背景缘由：
+     * UnPeekLiveData 通过 ViewModelStore 来在各种场景下（如旋屏后）确定订阅者的唯一性和消息的消费状况，
+     * 因而在 Activity 和 fragment 对 LifecycleOwner 的使用存在差异的现状下，
+     * 我们采取注入局部变量的方式，来获取 store 和 owner。
+     *
+     * @param owner
+     * @param observer
+     */
+    @Override
+    @Deprecated
+    public void observe(@NonNull LifecycleOwner owner, @NonNull Observer<? super T> observer) {
+        throw new IllegalArgumentException("请不要在 UnPeekLiveData 中使用 observe 方法。" +
+                "取而代之的是在 Activity 和 Fragment 中分别使用 observeInActivity 和 observeInFragment 来观察。\n\n" +
+                "Taking into account the normal permission of preventing backflow logic, " +
+                " do not use observeForever to communicate between pages." +
+                "Instead, you can use ObserveInActivity and ObserveInFragment methods " +
+                "to observe in Activity and Fragment respectively.");
+    }
+
+    /**
+     * TODO：Tip：请不要在 UnPeekLiveData 中使用 observeForever 方法。
+     * <p>
+     * 2020.8.1 背景缘由：
+     * UnPeekLiveData 主要用于表现层的 页面转场 和 页面间通信 场景下的非粘性消息分发，
+     * 出于生命周期安全等因素的考虑，不建议使用 observeForever 方法，
+     * <p>
+     * 对于数据层的工作，如有需要，可结合实际场景使用 RxJava 或 kotlin flow。
+     *
+     * @param observer
+     */
+    @Override
+    @Deprecated
+    public void observeForever(@NonNull Observer<? super T> observer) {
+        throw new IllegalArgumentException("出于生命周期安全的考虑，请不要在 UnPeekLiveData 中使用 observeForever 方法。\n\n" +
+                "Considering avoid lifecycle security issues," +
+                " do not use observeForever for communication between pages.");
+    }
+
+    public static class Builder<T> {
+
+        /**
+         * 是否允许传入 null value
+         */
+        private boolean isAllowNullValue;
+
+        public Builder<T> setAllowNullValue(boolean allowNullValue) {
+            this.isAllowNullValue = allowNullValue;
+            return this;
+        }
+
+        public UnPeekLiveData<T> create() {
+            UnPeekLiveData<T> liveData = new UnPeekLiveData<>();
+            liveData.isAllowNullValue = this.isAllowNullValue;
+            return liveData;
+        }
+    }
+}

--- a/unpeeklivedata/src/main/java/com/kunminx/architecture/ui/callback/util/LiveDataUtil.java
+++ b/unpeeklivedata/src/main/java/com/kunminx/architecture/ui/callback/util/LiveDataUtil.java
@@ -1,0 +1,62 @@
+package com.kunminx.architecture.ui.callback.util;
+
+/*
+ * Copyright 2021-present Jim
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import androidx.annotation.NonNull;
+import androidx.arch.core.internal.SafeIterableMap;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Observer;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+/**
+ * Create by Jim at 2021/4/21
+ */
+public class LiveDataUtil {
+
+    /**
+     * 通过反射，获取指定LiveData中的Observer对象
+     *
+     * @param liveData 指定的LiveData
+     * @param identityHashCode 想要获取的Observer对象的identityHashCode {@code System.identityHashCode}
+     * @return
+     */
+    public static Observer getObserver(@NonNull LiveData liveData, @NonNull Integer identityHashCode) {
+        if (liveData == null || identityHashCode == null) {
+            return null;
+        }
+
+        try {
+            Field field = LiveData.class.getDeclaredField("mObservers");
+            field.setAccessible(true);
+            SafeIterableMap<Observer, Object> observers = (SafeIterableMap<Observer, Object>) field.get(liveData);
+            if (observers != null) {
+                for (Map.Entry<Observer, Object> entry : observers) {
+                    Observer observer = entry.getKey();
+                    if (System.identityHashCode(observer) == identityHashCode) {
+                        return observer;
+                    }
+                }
+            }
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### 重构 UnPeekLiveDataV4版本
最终实现对谷歌原生 LiveData 完全无侵入性的目的。在多人协作的场景下，其他同学就只需要理解 UnPeekLiveData 能够解决粘性事件、数据倒灌问题，其他的完全不需要理解，用法上完全跟原生 LiveData 保持一致

#### 问题一：UnPeekLiveData 中的 observers 这个 HashMap 恒久存在，注册的 Observer 越多，占用的内存越大，并且除非UnPeekLiveData 被回收，否则恒久存在内存当中
解决：在 removeObserver 方法中移除 map 中对应存储的 storeId

#### 问题二：无法通过 removeObserver 方法移除指定的 Observer（某些场景需要提前 removeObserver）
解决：通过维护外部传入 Observer 与内部代理 Observer 的映射关系，在 removeObserver 调用时，通过反射找到真正注册到 LiveData 中的 Observer，实现移除

#### 问题三：同一个 Observer 对象，注册多次，UnPeekLiveData 内部实际上会注册了多个不同的 Observer，从而导致重复回调，产生一些不可预期的问题
解决：内部不会每次调用 observe 方法时都新创建一个代理 Observer，而是复用已经存在的代理 Observer（注意！！！Kotlin + LiveData + Lamda 由于编译器优化，可能会抛 Cannot add the same observer with different lifecycles 异常）

#### 问题四：无法使用 observerForever 方法
解决：UnPeekLiveData 内部直接持有 forever 类型的 Observer
